### PR TITLE
Upgrade Docker login action

### DIFF
--- a/docker-build-and-push/action.yml
+++ b/docker-build-and-push/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Log in to GitHub Docker Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ${{ inputs.docker-host }}
         username: ${{ inputs.docker-username }}


### PR DESCRIPTION
The current used action for logging into a Docker server is deprecated.

<img width="1091" alt="Bildschirm­foto 2022-11-22 um 11 55 48" src="https://user-images.githubusercontent.com/3337260/203296706-714630cb-6dcb-4d59-919b-a6f3df0eb050.png">

This PR upgrades this dependency, but you still have to test it if everything works.